### PR TITLE
Install prerequisites, & handle differences in fetch between 9.2 and 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,6 @@ bsd-cloudinit-installer
 
 Installs [bsd-cloudinit](https://github.com/pellaeon/bsd-cloudinit) and transforms VM into instance template.
 
-Currently only for FreeBSD 9.
-
 Todo
 ====
-1. Remove SSH host keys to trigger automatic key generation on next boot
-2. Install Python environment
-3. Add bsd-cloudinit to rc.local
+

--- a/installer.sh
+++ b/installer.sh
@@ -6,6 +6,22 @@ RC_BACKUP_FILE='/etc/rc.local.bak'
 RC_CONF='/etc/rc.conf'
 BSDINIT_URL="https://github.com/pellaeon/bsd-cloudinit/archive/master.tar.gz"
 
+BSD_VERSION=`uname -r |cut -d. -f 1`
+INSTALL_PKGS='py27-setuptools'
+VERIFY_PEER=''
+
+# For FreeBSD10 get root certs and use them
+if [ "$BSD_VERSION" -ge 10 ];then
+    INSTALL_PKGS="$INSTALL_PKGS ca_root_nss"
+    VERIFY_PEER="--ca-cert=/usr/local/share/certs/ca-root-nss.crt"
+fi
+
+
+# INstall our prerequisites
+pkg install $INSTALL_PKGS
+PATH=$PATH:/usr/local/bin
+easy_install eventlet
+easy_install iso8601
 
 [ ! `which python2.7` ] && {
 	echo 'python2.7 Not Found !' 
@@ -13,7 +29,7 @@ BSDINIT_URL="https://github.com/pellaeon/bsd-cloudinit/archive/master.tar.gz"
 	}
 PYTHON=`which python2.7`
 
-fetch --no-verify-peer -o - $BSDINIT_URL | tar -xzvf - -C '/root'
+fetch $VERIFY_PEER -o - $BSDINIT_URL | tar -xzvf - -C '/root'
 
 rm -vf $SSH_DIR/ssh_host*
 


### PR DESCRIPTION
in 9.2 ca-root-nss is in ports not main and fetch doesn't take any options
relating to peer verification (no verification can be done) so no need of them either.

In 10 we can get and use ca root certs to verify our https connection to github, so we should.
